### PR TITLE
Arc 1057 fix memory leak gopsutil

### DIFF
--- a/disk/disk_windows.go
+++ b/disk/disk_windows.go
@@ -95,7 +95,8 @@ func UsageWithContext(_ context.Context, path string) (*UsageStat, error) {
 // this can be slow, the system call is not interruptible
 func getLogicaldrives(ctx context.Context) ([]string, error) {
 	// We first call GetLogicalDriveStringsW with a buffer length of 0 to get the required buffer size.
-	len, _, err := procGetLogicalDriveStringsW.Call(
+	// https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getlogicaldrivestringsw
+	bufferLen, _, err := procGetLogicalDriveStringsW.Call(
 		uintptr(0),
 		uintptr(0))
 
@@ -106,9 +107,9 @@ func getLogicaldrives(ctx context.Context) ([]string, error) {
 		return nil, ctx.Err() // Context canceled, don't retry (The call can be slow)
 	}
 
-	lpBuffer := make([]uint16, len)
+	lpBuffer := make([]uint16, bufferLen)
 	_, _, err = procGetLogicalDriveStringsW.Call(
-		uintptr(len),
+		uintptr(bufferLen),
 		uintptr(unsafe.Pointer(&lpBuffer[0])))
 	if err != windows.ERROR_SUCCESS {
 		return nil, err // The call failed with an unexpected error

--- a/disk/disk_windows.go
+++ b/disk/disk_windows.go
@@ -34,6 +34,7 @@ var (
 	procGetVolumePathNamesForVolumeNameW = common.Modkernel32.NewProc("GetVolumePathNamesForVolumeNameW")
 )
 
+// https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getvolumeinformationa#parameters
 const (
 	rw       = "rw"
 	ro       = "ro"

--- a/disk/disk_windows.go
+++ b/disk/disk_windows.go
@@ -34,6 +34,12 @@ var (
 	procGetVolumePathNamesForVolumeNameW = common.Modkernel32.NewProc("GetVolumePathNamesForVolumeNameW")
 )
 
+const (
+	rw       = "rw"
+	ro       = "ro"
+	compress = "compress"
+)
+
 var (
 	fileFileCompression = int64(16)     // 0x00000010
 	fileReadOnlyVolume  = int64(524288) // 0x00080000
@@ -241,12 +247,12 @@ func buildPartitionStat(path string) (PartitionStat, error) {
 			return PartitionStat{}, err
 		}
 
-		opts := []string{"rw"}
+		opts := []string{rw}
 		if fsFlags&fileReadOnlyVolume != 0 {
-			opts = []string{"ro"}
+			opts = []string{ro}
 		}
 		if fsFlags&fileFileCompression != 0 {
-			opts = append(opts, "compress")
+			opts = append(opts, compress)
 		}
 
 		return PartitionStat{

--- a/disk/disk_windows_test.go
+++ b/disk/disk_windows_test.go
@@ -1,0 +1,20 @@
+package disk
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetLogicalDrives(t *testing.T) {
+	ctx := context.Background()
+	drives, err := getLogicaldrives(ctx)
+	require.NoError(t, err)
+	assert.Greater(t, len(drives), 0)
+	for _, d := range drives {
+		assert.NotEmpty(t, d)
+	}
+	assert.Contains(t, drives, `C:\`)
+}

--- a/disk/disk_windows_test.go
+++ b/disk/disk_windows_test.go
@@ -27,7 +27,6 @@ func TestGetLogicalDrives(t *testing.T) {
 }
 
 func TestBuildPartitionStat(t *testing.T) {
-	t.Skip("this creates VHD partitions and requires admin rights, execute the test mnually")
 	volumeC := `C:\`
 	part, err := buildPartitionStat(volumeC)
 	require.NoError(t, err)
@@ -38,6 +37,8 @@ func TestBuildPartitionStat(t *testing.T) {
 }
 
 func TestGetPartStatFromVolumeName(t *testing.T) {
+	t.Skip("this creates VHD partitions and requires admin rights, execute the test mnually")
+
 	driveLetter := "Y"
 	mountFolder := `C:\mountpoint\`
 	testMountedVolumesAsFolder(t, driveLetter, "")

--- a/disk/disk_windows_test.go
+++ b/disk/disk_windows_test.go
@@ -27,6 +27,7 @@ func TestGetLogicalDrives(t *testing.T) {
 }
 
 func TestBuildPartitionStat(t *testing.T) {
+	t.Skip("this creates VHD partitions and requires admin rights, execute the test mnually")
 	volumeC := `C:\`
 	part, err := buildPartitionStat(volumeC)
 	require.NoError(t, err)
@@ -39,12 +40,9 @@ func TestBuildPartitionStat(t *testing.T) {
 func TestGetPartStatFromVolumeName(t *testing.T) {
 	driveLetter := "Y"
 	mountFolder := `C:\mountpoint\`
-	longMountFolder := `C:\this\is\a\very\long\mountpoint\to\test\the\maximum\path\length\allowed\by\windows\operating\system\for\mounted\volumes\as\folders\in\the\file\system\structure\of\the\os\itself\and\see\if\there\are\any\issues\with\paths\longer\than\the\traditional\260\character\limit\which\was\present\in\older\versions\of\windows\operating\system\and\is\still\a\common\issue\for\many\applications\ok\this\is\just\a\very\long\text\to\test\if\we\are\calling\the\api\correctly\it\is\not\exptected\that\you\read\it`
 	testMountedVolumesAsFolder(t, driveLetter, "")
 	testMountedVolumesAsFolder(t, driveLetter, mountFolder)
 	testMountedVolumesAsFolder(t, "", mountFolder)
-	testMountedVolumesAsFolder(t, driveLetter, longMountFolder)
-	testMountedVolumesAsFolder(t, "", longMountFolder)
 }
 
 func testMountedVolumesAsFolder(t *testing.T, driveLetter string, mountFolder string) {
@@ -77,14 +75,14 @@ func mountVolume(t *testing.T, driveLetter string, vhdFile string, mountFolder s
 	if mountFolder != "" {
 		args = append(args, "-MountFolder", mountFolder)
 	}
-	mountVolumeCmd := exec.Command("powershell.exe", args...)
+	mountVolumeCmd := exec.Command("pwsh.exe", args...)
 	out, createVolumeErr := mountVolumeCmd.Output()
 	require.NoError(t, createVolumeErr, out)
 }
 
 func removeMountedVolume(t *testing.T, vhdFile string, mountFolder string) {
 	if _, statErr := os.Stat(vhdFile); statErr == nil {
-		unmountVolumeCmd := exec.Command("powershell.exe", "-File", removeVolumeScript, "-VhdPath", vhdFile, "-MountFolder", mountFolder)
+		unmountVolumeCmd := exec.Command("pwsh.exe", "-File", removeVolumeScript, "-VhdPath", vhdFile, "-MountFolder", mountFolder)
 		out, unmountVolumeErr := unmountVolumeCmd.CombinedOutput()
 		require.NoError(t, unmountVolumeErr, out)
 	}

--- a/disk/disk_windows_test.go
+++ b/disk/disk_windows_test.go
@@ -18,3 +18,13 @@ func TestGetLogicalDrives(t *testing.T) {
 	}
 	assert.Contains(t, drives, `C:\`)
 }
+
+func TestBuildPartitionStat(t *testing.T) {
+	volumeC := `C:\`
+	part, err := buildPartitionStat(volumeC)
+	require.NoError(t, err)
+	assert.Equal(t, volumeC, part.Mountpoint)
+	assert.Equal(t, volumeC, part.Device)
+	assert.Equal(t, "NTFS", part.Fstype) // NTFS should be the only allowed fs on C: drive
+	assert.Contains(t, part.Opts, "rw")  // C: must have atleast rw option
+}

--- a/disk/disk_windows_test.go
+++ b/disk/disk_windows_test.go
@@ -2,10 +2,18 @@ package disk
 
 import (
 	"context"
+	"os"
+	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+)
+
+const (
+	createVolumeScript = `.\testdata\windows\create_volume.ps1`
+	removeVolumeScript = `.\testdata\windows\remove_volume.ps1`
 )
 
 func TestGetLogicalDrives(t *testing.T) {
@@ -27,4 +35,34 @@ func TestBuildPartitionStat(t *testing.T) {
 	assert.Equal(t, volumeC, part.Device)
 	assert.Equal(t, "NTFS", part.Fstype) // NTFS should be the only allowed fs on C: drive
 	assert.Contains(t, part.Opts, "rw")  // C: must have atleast rw option
+}
+
+func TestGetPartStatFromVolumeName(t *testing.T) {
+	driveLetter := "Y"
+	vhdFile := `C:\testdisk.vhd`
+	mountFolder := `C:\mountpoint`
+	removeMountedVolume(t, vhdFile, mountFolder)
+
+	mountVolume(t, driveLetter, vhdFile, mountFolder)
+	warnings := Warnings{}
+	processedPaths := make(map[string]struct{})
+	partitionsStats := make([]PartitionStat, 0)
+	drivePath := driveLetter + `:\`
+	volNameBuffer := windows.StringToUTF16(drivePath)
+	getPartStatFromVolumeName(context.Background(), volNameBuffer, &warnings, processedPaths, partitionsStats)
+	assert.Empty(t, warnings.List)
+}
+
+func mountVolume(t *testing.T, driveLetter string, vhdFile string, mountFolder string) {
+	mountVolumeCmd := exec.Command("powershell.exe", "-File", createVolumeScript, "-DriveLetter", driveLetter, "-VhdPath", vhdFile, "-MountFolder", mountFolder)
+	out, createVolumeErr := mountVolumeCmd.Output()
+	require.NoError(t, createVolumeErr, out)
+}
+
+func removeMountedVolume(t *testing.T, vhdFile string, mountFolder string) {
+	if _, statErr := os.Stat(vhdFile); statErr == nil {
+		unmountVolumeCmd := exec.Command("powershell.exe", "-File", removeVolumeScript, "-VhdPath", vhdFile, "-MountFolder", mountFolder)
+		out, unmountVolumeErr := unmountVolumeCmd.CombinedOutput()
+		require.NoError(t, unmountVolumeErr, out)
+	}
 }

--- a/disk/disk_windows_test.go
+++ b/disk/disk_windows_test.go
@@ -33,7 +33,7 @@ func TestBuildPartitionStat(t *testing.T) {
 	assert.Equal(t, volumeC, part.Mountpoint)
 	assert.Equal(t, volumeC, part.Device)
 	assert.Equal(t, "NTFS", part.Fstype) // NTFS should be the only allowed fs on C: drive
-	assert.Contains(t, part.Opts, "rw")  // C: must have atleast rw option
+	assert.Contains(t, part.Opts, rw)    // C: must have atleast rw option
 }
 
 func TestGetPartStatFromVolumeName(t *testing.T) {
@@ -49,7 +49,7 @@ func TestGetPartStatFromVolumeName(t *testing.T) {
 func testMountedVolumesAsFolder(t *testing.T, driveLetter string, mountFolder string) {
 	fsType := "NTFS"
 	vhdFile := `C:\testdisk.vhd`
-	opts := []string{"rw", "compress"}
+	opts := []string{rw, compress}
 	letterMountPoint := driveLetter + `:\`
 	defer removeMountedVolume(t, vhdFile, mountFolder)
 

--- a/disk/testdata/windows/create_volume.ps1
+++ b/disk/testdata/windows/create_volume.ps1
@@ -1,0 +1,39 @@
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$VhdPath,
+    [Parameter(Mandatory=$false)]
+    [string]$DriveLetter,
+    [Parameter(Mandatory=$false)]
+    [string]$MountFolder
+)
+
+# Create diskpart script
+$diskpartScript = @"
+create vdisk file="$VhdPath" maximum=10 type=expandable
+select vdisk file="$VhdPath"
+attach vdisk
+create partition primary
+format fs=ntfs quick`r`n
+"@
+
+if ($DriveLetter) {
+    $diskpartScript += "assign letter=$DriveLetter`r`n"
+}
+
+$diskpartScriptPath = "$env:TEMP\diskpart_script.txt"
+$diskpartScript | Set-Content -Path $diskpartScriptPath
+
+# Run diskpart
+diskpart /s $diskpartScriptPath
+
+# Mount to folder if specified
+if ($MountFolder) {
+    # Get the volume object
+    $vol = Get-WmiObject -Query "SELECT * FROM Win32_Volume WHERE DriveLetter = '${DriveLetter}:'"
+    if ($vol) {
+        $vol.AddMountPoint($MountFolder)
+    }
+}
+
+# Cleanup
+Remove-Item $diskpartScriptPath -Force

--- a/disk/testdata/windows/remove_volume.ps1
+++ b/disk/testdata/windows/remove_volume.ps1
@@ -1,0 +1,26 @@
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$VhdPath,
+    [Parameter(Mandatory=$false)]
+    [string]$MountFolder
+)
+
+# Detach the VHD
+$diskpartScript = @"
+select vdisk file="$VhdPath"
+detach vdisk
+"@
+$diskpartScriptPath = "$env:TEMP\diskpart_remove_script.txt"
+$diskpartScript | Set-Content -Path $diskpartScriptPath
+diskpart /s $diskpartScriptPath
+Remove-Item $diskpartScriptPath -Force
+
+# Delete the VHD file
+if (Test-Path $VhdPath) {
+    Remove-Item $VhdPath -Force
+}
+
+# Remove mount folder if specified
+if ($MountFolder -and (Test-Path $MountFolder)) {
+    Remove-Item $MountFolder -Recurse -Force
+}

--- a/internal/common/warnings.go
+++ b/internal/common/warnings.go
@@ -3,12 +3,17 @@ package common
 
 import "fmt"
 
+const MaxWarnings = 100 // An arbitrary limit to avoid excessive memory usage, it has no sense to store thousands of errors
+
 type Warnings struct {
 	List    []error
 	Verbose bool
 }
 
 func (w *Warnings) Add(err error) {
+	if len(w.List) >= MaxWarnings {
+		return
+	}
 	w.List = append(w.List, err)
 }
 


### PR DESCRIPTION
Limited warning list to avoid memory leak
Removed leaking goroutine and implemented context correctly, the code is stopped as soon as we can, the syscall is not interruptible, leaving a leaking goroutine is dangerous if code is called multiple times.
Implemented windows API correctly, max paths are now set correctly and we require the buffer length when necessary.
If we receive an unexpected error while iterating volumes, I return, this fixes the infinite loop.


